### PR TITLE
 Change OS from Ubuntu 18.04 to 22.04 on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 RUN apt-get update && apt-get install -y git make build-essential liblzma-dev libbz2-dev zlib1g-dev libncurses5-dev libncursesw5-dev
 


### PR DESCRIPTION
## Description

Fix [IN-669](https://saphetor.atlassian.net/browse/IN-669)
Update base image from Ubuntu 18 to Ubuntu 22 .

## Changes

Changed base image to Ubuntu 22.04. Tested locally. No errrors during the build.

![Screenshot from 2024-02-20 11-08-18](https://github.com/xjtu-omics/msisensor-pro/assets/121862515/5e54b8da-40a8-4a2c-97c6-220f888fc10c)
